### PR TITLE
fix: use oidc as user id

### DIFF
--- a/src/models/SynapseService.ts
+++ b/src/models/SynapseService.ts
@@ -36,17 +36,15 @@ function produceSynapseUserId(
   member: ProposalUser,
   skipPrePostfix: boolean = false
 ): string {
-  const fullName =
-    member.firstName.toLocaleLowerCase() + member.lastName.toLocaleLowerCase();
-  const normalizedFullName = fullName
+  const normalizedId = member.oidcSub
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '');
 
   if (skipPrePostfix) {
-    return normalizedFullName;
+    return normalizedId;
   }
 
-  return `@${normalizedFullName}:${serverName}`;
+  return `@${normalizedId}:${serverName}`;
 }
 
 export class SynapseService {


### PR DESCRIPTION
<!--- You can leave blank or remove sections that aren't necessary for the PR. -->

## Description

This PR changes the unique user identifier to the ID from OIDC in stead of firstnamelastname format. This is because we don't want a new chatroom user in case the user updates his name, because it is still the same user.
We don't want conflicts if two users have the same first and last name
