### PR TITLE
SWAP-2928 round 3: retrieving instrument name from message

### DIFF
--- a/src/models/ProposalMessage.ts
+++ b/src/models/ProposalMessage.ts
@@ -1,4 +1,10 @@
 import { ProposalUser } from './../queue/consumers/scicat/scicatProposal/dto';
+
+export type Instrument = {
+  id: number;
+  shortCode: string;
+}
+
 export type ProposalMessageData = {
   proposalPk: number;
   shortCode: string;
@@ -7,4 +13,5 @@ export type ProposalMessageData = {
   newStatus?: string;
   members: ProposalUser[];
   proposer?: ProposalUser;
+  instrument?: Instrument;
 };

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.ts
@@ -5,37 +5,6 @@ import fetch from 'node-fetch';
 
 import { ValidProposalMessageData } from '../utils/validateProposalMessage';
 
-const folderCreationCommand = process.env.FOLDER_CREATION_COMMAND;
-
-const getInstrumentName = async (proposalId: string) => {
-  const response = await fetch(process.env.USER_OFFICE_GRAPHQL_URL! as string, {
-    headers: {
-      'content-type': 'application/json',
-      Authorization: 'Bearer ' + process.env.USER_OFFICE_JWT,
-    },
-    body:
-      '{"operationName":null,"variables":{},"query":"{\\n  proposalById(proposalId: \\"' +
-      proposalId +
-      '\\") {\\n    title\\n    instrument {\\n      name\\n    }\\n  }\\n}\\n"}',
-    method: 'POST',
-  });
-
-  try {
-    const {
-      proposalById: { instrument: name },
-    } = await response.json();
-
-    return name as string;
-  } catch (error) {
-    logger.logError('Request for instrument name failed', {
-      error: error,
-      statusCode: response.status,
-      statusText: response.statusText,
-      body: response.body,
-    });
-  }
-};
-
 const proposalFoldersCreation = async (
   proposalMessage: ValidProposalMessageData
 ) => {

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.ts
@@ -42,7 +42,7 @@ const proposalFoldersCreation = async (
   // prepare path with correct year, instrument, proposal
   const proposalId = proposalMessage.shortCode;
   const year = new Date().getFullYear().toString();
-  const instrument = proposalMessage.instrument.shortCode;
+  const instrument = proposalMessage.instrument.shortCode.toLowerCase();
   logger.logInfo('Preparing year, instrument and proposal', {
     proposalId: proposalId,
     year: year,

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.ts
@@ -42,15 +42,7 @@ const proposalFoldersCreation = async (
   // prepare path with correct year, instrument, proposal
   const proposalId = proposalMessage.shortCode;
   const year = new Date().getFullYear().toString();
-  let instrument = (await getInstrumentName(
-    proposalMessage.shortCode
-  )) as string;
-  if (!instrument) {
-    logger.logError('Instrument name not found', {});
-
-    return;
-  }
-  instrument = instrument.toLowerCase();
+  const instrument = proposalMessage.instrument.shortCode;
   logger.logInfo('Preparing year, instrument and proposal', {
     proposalId: proposalId,
     year: year,

--- a/src/queue/consumers/scicat/scicatProposal/utils/validateProposalMessage.ts
+++ b/src/queue/consumers/scicat/scicatProposal/utils/validateProposalMessage.ts
@@ -32,5 +32,9 @@ export function validateProposalMessage(
     throw new Error('Proposal short code is missing');
   }
 
+  if (!proposalMessage.instrument) {
+    throw new Error('Instrument is missing');
+  }
+
   return proposalMessage as ValidProposalMessageData;
 }


### PR DESCRIPTION
## Description

The message sent from User Office now contains the instrument information. So we do not need an extra call for the instrument name

## How Has This Been Tested

Relying on CI for testing

## Changes

In callbacks for proposals folders creation, I removed the function to retrieve the instrument name from user office.
The instrument name is extracted from the message received.
Validation for the instrument information has been added

## Depends on

no dependencies
