### PR TITLE
SWAP 2928 4: instantiate serivecs on demand

### DIFF
--- a/src/config/Tokens.ts
+++ b/src/config/Tokens.ts
@@ -2,4 +2,5 @@
 export const Tokens = {
   ProvideMessageBroker: Symbol('MessageBroker'),
   ConfigureLogger: Symbol('ConfigureLogger'),
+  SynapseService: Symbol('SynapseService'),
 };

--- a/src/config/dependencyConfigRun.ts
+++ b/src/config/dependencyConfigRun.ts
@@ -1,8 +1,15 @@
 import 'reflect-metadata';
 import { configureConsoleLogger } from './logger/configureConsoleLogger';
 import { Tokens } from './Tokens';
-import { mapValue } from './utils';
+import { mapClass, mapValue, str2Bool } from './utils';
 import getRabbitMqMessageBroker from '../queue/messageBroker/getRabbitMqMessageBroker';
+import { SynapseService } from '../services/synapse/SynapseService';
 
 mapValue(Tokens.ConfigureLogger, configureConsoleLogger);
 mapValue(Tokens.ProvideMessageBroker, getRabbitMqMessageBroker);
+
+const enableNicosToScichatMessages = str2Bool(
+    process.env.ENABLE_NICOS_TO_SCICHAT_MESSAGES as string
+);
+
+mapValue(Tokens.SynapseService, ( enableNicosToScichatMessages ? new SynapseService() : {}));

--- a/src/queue/consumers/nicos/consumerCallbacks/postNicosMessage.ts
+++ b/src/queue/consumers/nicos/consumerCallbacks/postNicosMessage.ts
@@ -1,6 +1,6 @@
+import { container } from 'tsyringe';
+import { Tokens } from '../../../../config/Tokens';
 import { SynapseService } from '../../../../services/synapse/SynapseService';
-
-const synapseService: SynapseService = new SynapseService();
 
 const postNicosMessage = async ({
   roomName,
@@ -9,6 +9,7 @@ const postNicosMessage = async ({
   roomName: string;
   message: string;
 }) => {
+  const synapseService: SynapseService = container.resolve(Tokens.SynapseService);
   await synapseService.sendMessage(roomName, message);
 };
 

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/createChatroom.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/createChatroom.ts
@@ -1,12 +1,12 @@
 import { logger } from '@user-office-software/duo-logger';
+import { container } from 'tsyringe';
+import { Tokens } from '../../../../../config/Tokens';
 
 import { SynapseService } from '../../../../../services/synapse/SynapseService';
 import { ProposalUser } from '../dto';
 import { ValidProposalMessageData } from '../utils/validateProposalMessage';
 
 const defaultPassword = process.env.SYNAPSE_NEW_USER_DEFAULT_PASSWORD || '';
-
-const synapseService = new SynapseService();
 
 function isValidUser(user: ProposalUser) {
   return user?.oidcSub && user?.firstName && user?.lastName && user?.email;
@@ -26,6 +26,8 @@ function validateUsers(users: ProposalUser[]) {
   return { validUsers, invalidUsers };
 }
 const createChatroom = async (message: ValidProposalMessageData) => {
+
+  const synapseService: SynapseService = container.resolve(Tokens.SynapseService);
   const allUsersOnProposal = [...message.members, message.proposer];
 
   const { validUsers, invalidUsers } = validateUsers(allUsersOnProposal);


### PR DESCRIPTION
## Description
This PR instantiate the Synapse Service only if the functionality is enabled.

## Motivation and Context
We noticed that when activating only the proposals folders creation, the synapse service was also instantiated, leading to a failure in the service as scichat was not accessible from the location.
We decided to instantiate synapse service conditionally to the configuration

## How Has This Been Tested
Locally on my machine. Soon on the dev environment

## Changes
Changes Nicos to scichat and scichat chat room creation, so the synapse service is instantiated only if they are enable

## Depends on
No dependencies

