### PR TITLE
fix: kafka consumer crash fix & added restart on crash

### DIFF
--- a/src/queue/consumers/nicos/NicosTopicConsumer.ts
+++ b/src/queue/consumers/nicos/NicosTopicConsumer.ts
@@ -12,9 +12,8 @@ export class TopicSciChatConsumer {
       { topics: [topic] },
       {
         eachMessage: async ({ message }) => {
-          const messageData = JSON.parse(message.value?.toString() as string);
-
           try {
+            const messageData = JSON.parse(message.value?.toString() as string);
             const validMessageData = validateNicosMessage(messageData);
 
             await postNicosMessage({


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

- Fixed Json parse error cause kafka consumer crashing issue
- Added consumer restart feature on crash with maximum retry 5 times per 10 seconds

## Motivation and Context

Certain erros causing kafka consumer to completly stop. We cannot prevent all the causes, but we should try to avoid as much as possible.

## How Has This Been Tested

- mannual


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
