### PR TITLE
chore: do not login or push the image if dependabot is creating the PR

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -37,13 +37,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Login to GitHub Container Registry
+        # Don't login if dependabot is creating the PR
+        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -53,7 +49,5 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          push: true
-          tags: |
-            dmsc/connector:${{ github.head_ref }}
-            ghcr.io/userofficeproject/connector:${{ github.head_ref }}
+          push: ${{ !startsWith(github.head_ref, 'dependabot') }}
+          tags: ghcr.io/userofficeproject/connector:${{ github.head_ref }}


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Avoid pushing to the registry if dependabot is creating version/security update