### PR TITLE
fix: logError function is used to log errors and not logInfo when an error occurs

### DIFF
--- a/src/queue/consumers/generic/genericFoldersCreationCallBack.spec.ts
+++ b/src/queue/consumers/generic/genericFoldersCreationCallBack.spec.ts
@@ -1,0 +1,54 @@
+jest.mock('node:child_process');
+jest.mock('@user-office-software/duo-logger');
+
+import { exec } from 'node:child_process';
+
+import { logger } from '@user-office-software/duo-logger';
+
+import { genericFoldersCreation } from './genericFoldersCreationCallBack';
+
+describe('genericFoldersCreation', () => {
+  let mockLoggerLogError: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockLoggerLogError = jest.spyOn(logger, 'logError');
+  });
+
+  it('should use logError when the cb function of "exec" command is called with an error', () => {
+    (exec as unknown as jest.Mock).mockImplementationOnce(
+      (command, callback) => {
+        callback(new Error('test error'), undefined, undefined);
+      }
+    );
+
+    genericFoldersCreation({ test: 'test' }, 'test command');
+
+    expect(mockLoggerLogError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerLogError).toHaveBeenCalledWith(
+      'Unable to create folders with error',
+      {
+        command: 'test command',
+        errorMessage: 'test error',
+      }
+    );
+  });
+
+  it('should use logError when the cb function of "exec" command is called with stderr', () => {
+    (exec as unknown as jest.Mock).mockImplementationOnce(
+      (command, callback) => {
+        callback(undefined, undefined, 'test stderr');
+      }
+    );
+
+    genericFoldersCreation({ test: 'test' }, 'test command');
+
+    expect(mockLoggerLogError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerLogError).toHaveBeenCalledWith(
+      'Unable to create folders with stderr',
+      {
+        command: 'test command',
+        stderr: 'test stderr',
+      }
+    );
+  });
+});

--- a/src/queue/consumers/generic/genericFoldersCreationCallBack.ts
+++ b/src/queue/consumers/generic/genericFoldersCreationCallBack.ts
@@ -42,7 +42,7 @@ const genericFoldersCreation = async (
   // run command
   exec(command, (error, stdout, stderr) => {
     if (error) {
-      logger.logInfo('Unable to create folders with error', {
+      logger.logError('Unable to create folders with error', {
         command: command,
         errorMessage: error.message,
       });
@@ -50,7 +50,7 @@ const genericFoldersCreation = async (
       return;
     }
     if (stderr) {
-      logger.logInfo('Unable to create folders with stderr', {
+      logger.logError('Unable to create folders with stderr', {
         command: command,
         stderr: stderr,
       });

--- a/src/queue/consumers/moodle/MoodleFolderCreationQueueConsumer.spec.ts
+++ b/src/queue/consumers/moodle/MoodleFolderCreationQueueConsumer.spec.ts
@@ -1,0 +1,66 @@
+jest.mock('../utils/validateMessages');
+jest.mock('../QueueConsumer', () => ({
+  QueueConsumer: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+  })),
+}));
+jest.mock('@user-office-software/duo-logger');
+
+import { logger } from '@user-office-software/duo-logger';
+import { MessageBroker } from '@user-office-software/duo-message-broker';
+
+import { MoodleFolderCreationQueueConsumer } from './MoodleFolderCreationQueueConsumer';
+import { validateMoodleMessage } from '../utils/validateMessages';
+
+describe('MoodleFolderCreationQueueConsumer', () => {
+  let mockLoggerLogError: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockLoggerLogError = jest.spyOn(logger, 'logError');
+  });
+
+  it('should use logError when MOODLE_FOLDERS_CREATION_COMMAND env. variable is missing', async () => {
+    (validateMoodleMessage as jest.Mock).mockReturnValueOnce(true);
+
+    const consumer = new MoodleFolderCreationQueueConsumer({} as MessageBroker);
+
+    const error = await consumer
+      .onMessage('type', { message: 'message' }, {} as any)
+      .then(() => {
+        throw new Error('Should not be called');
+      })
+      .catch((err) => err);
+
+    expect(error).toEqual(
+      new Error('MOODLE_FOLDERS_CREATION_COMMAND env variable is missing')
+    );
+    expect(mockLoggerLogError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerLogError).toHaveBeenCalledWith(
+      'MOODLE_FOLDERS_CREATION_COMMAND env variable is missing',
+      {
+        command: undefined,
+        errorMessage: 'MOODLE_FOLDERS_CREATION_COMMAND env variable is missing',
+      }
+    );
+  });
+
+  it('should use logError when message is not valid', () => {
+    (validateMoodleMessage as jest.Mock).mockReturnValueOnce(false);
+
+    const consumer = new MoodleFolderCreationQueueConsumer({} as MessageBroker);
+
+    consumer.onMessage('type', { message: 'message' }, {} as any);
+
+    expect(mockLoggerLogError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerLogError).toHaveBeenCalledWith(
+      'Message does not have the correct arguments',
+      {
+        arg0: 'type',
+        message: {
+          message: 'message',
+        },
+        properties: {},
+      }
+    );
+  });
+});

--- a/src/queue/consumers/moodle/MoodleFolderCreationQueueConsumer.ts
+++ b/src/queue/consumers/moodle/MoodleFolderCreationQueueConsumer.ts
@@ -23,7 +23,7 @@ export class MoodleFolderCreationQueueConsumer extends QueueConsumer {
 
     if (validMessage) {
       if (!MOODLE_FOLDERS_CREATION_COMMAND) {
-        logger.logInfo(
+        logger.logError(
           'MOODLE_FOLDERS_CREATION_COMMAND env variable is missing',
           {
             command: MOODLE_FOLDERS_CREATION_COMMAND,
@@ -39,7 +39,7 @@ export class MoodleFolderCreationQueueConsumer extends QueueConsumer {
 
       genericFoldersCreation(validMessage, MOODLE_FOLDERS_CREATION_COMMAND);
     } else {
-      logger.logInfo('Message does not have the correct arguments', {
+      logger.logError('Message does not have the correct arguments', {
         arg0,
         message,
         properties,

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.spec.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.spec.ts
@@ -1,0 +1,66 @@
+jest.mock('node:child_process');
+jest.mock('node:process', () => ({
+  env: {
+    PROPOSAL_FOLDERS_CREATION_COMMAND: 'test command',
+  },
+}));
+jest.mock('@user-office-software/duo-logger');
+
+import { exec } from 'node:child_process';
+
+import { logger } from '@user-office-software/duo-logger';
+
+import { proposalFoldersCreation } from './proposalFoldersCreation';
+import { ValidProposalMessageData } from '../../../utils/validateProposalMessage';
+
+describe('proposalFoldersCreation', () => {
+  const proposalMessage = {
+    shortCode: 'shortCode',
+    instrument: {
+      shortCode: 'shortCode',
+    },
+  } as ValidProposalMessageData;
+  let mockLoggerLogError: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockLoggerLogError = jest.spyOn(logger, 'logError');
+  });
+
+  it('should use logError when the cb function of "exec" command is called with an error', () => {
+    (exec as unknown as jest.Mock).mockImplementationOnce(
+      (command, callback) => {
+        callback(new Error('test error'), undefined, undefined);
+      }
+    );
+
+    proposalFoldersCreation(proposalMessage);
+
+    expect(mockLoggerLogError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerLogError).toHaveBeenCalledWith(
+      'Unable to create folders with error',
+      {
+        command: 'test command',
+        errorMessage: 'test error',
+      }
+    );
+  });
+
+  it('should use logError when the cb function of "exec" command is called with stderr', () => {
+    (exec as unknown as jest.Mock).mockImplementationOnce(
+      (command, callback) => {
+        callback(undefined, undefined, 'test stderr');
+      }
+    );
+
+    proposalFoldersCreation(proposalMessage);
+
+    expect(mockLoggerLogError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerLogError).toHaveBeenCalledWith(
+      'Unable to create folders with stderr',
+      {
+        command: 'test command',
+        stderr: 'test stderr',
+      }
+    );
+  });
+});

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.ts
@@ -1,4 +1,5 @@
 import { exec } from 'node:child_process';
+import { env } from 'node:process';
 
 import { logger } from '@user-office-software/duo-logger';
 
@@ -18,7 +19,7 @@ const proposalFoldersCreation = async (
   });
 
   // update command
-  const command = (process.env.PROPOSAL_FOLDERS_CREATION_COMMAND! as string)
+  const command = (env.PROPOSAL_FOLDERS_CREATION_COMMAND! as string)
     .replace(/<INSTRUMENT>/, instrument)
     .replace(/<YEAR>/, year)
     .replace(/<PROPOSAL>/, proposalId);
@@ -27,7 +28,7 @@ const proposalFoldersCreation = async (
   // run command
   exec(command, (error, stdout, stderr) => {
     if (error) {
-      logger.logInfo('Unable to create folders with error', {
+      logger.logError('Unable to create folders with error', {
         command: command,
         errorMessage: error.message,
       });
@@ -35,7 +36,7 @@ const proposalFoldersCreation = async (
       return;
     }
     if (stderr) {
-      logger.logInfo('Unable to create folders with stderr', {
+      logger.logError('Unable to create folders with stderr', {
         command: command,
         stderr: stderr,
       });

--- a/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.spec.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.spec.ts
@@ -1,0 +1,50 @@
+jest.mock('../../../utils/validateMessages');
+jest.mock('../../../utils/hasTriggeringStatus');
+jest.mock('../../../utils/hasTriggeringType');
+jest.mock('../../../QueueConsumer', () => ({
+  QueueConsumer: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+  })),
+}));
+jest.mock('@user-office-software/duo-logger');
+
+import { logger } from '@user-office-software/duo-logger';
+import { MessageBroker } from '@user-office-software/duo-message-broker';
+
+import { FolderCreationQueueConsumer } from './FolderCreationQueueConsumer';
+import { hasTriggeringStatus } from '../../../utils/hasTriggeringStatus';
+import { hasTriggeringType } from '../../../utils/hasTriggeringType';
+import { validateProposalMessage } from '../../../utils/validateMessages';
+
+describe('FolderCreationQueueConsumer', () => {
+  it.each([
+    [false, false],
+    [false, true],
+    [true, false],
+  ])(
+    'should use logError when message does not have the correct type or status',
+    (hasStatus, hasType) => {
+      (validateProposalMessage as jest.Mock).mockReturnValueOnce({
+        newStatus: 'newStatus',
+      });
+      (hasTriggeringStatus as jest.Mock).mockReturnValueOnce(hasStatus);
+      (hasTriggeringType as jest.Mock).mockReturnValueOnce(hasType);
+      const mockLoggerLogError = jest.spyOn(logger, 'logError');
+
+      const consumer = new FolderCreationQueueConsumer({} as MessageBroker);
+
+      consumer.onMessage('type', { message: 'message' }, {
+        headers: {},
+      } as any);
+
+      expect(mockLoggerLogError).toHaveBeenCalledTimes(1);
+      expect(mockLoggerLogError).toHaveBeenCalledWith(
+        'Message does not have the correct type or status',
+        {
+          status: 'newStatus',
+          type: 'type',
+        }
+      );
+    }
+  );
+});

--- a/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.ts
@@ -38,7 +38,7 @@ export class FolderCreationQueueConsumer extends QueueConsumer {
     if (hasStatus && hasType) {
       proposalFoldersCreation(proposalMessage);
     } else {
-      logger.logInfo('Message does not have the correct type or status', {
+      logger.logError('Message does not have the correct type or status', {
         type: type,
         status: proposalMessage.newStatus,
       });


### PR DESCRIPTION
## Description

"logError" function has to be used when an error occurs

## Motivation and Context

There are instances in the codebase where the 'logInfo' function is used when an error occurs, and this can lead to a lack of visibility when actual errors occur.

## How Has This Been Tested

- Unit Testing

## Tests included/Docs Updated?

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
