### PR TITLE
fix: reduce unnecessary error logs if queue message does not have right type or status

### DIFF
--- a/src/queue/consumers/scicat/scicatProposal/consumers/ChatroomCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/ChatroomCreationQueueConsumer.ts
@@ -26,14 +26,18 @@ export class ChatroomCreationQueueConsumer extends QueueConsumer {
   }
 
   onMessage: ConsumerCallback = async (type, message) => {
+    const hasType = hasTriggeringType(type, EVENT_TYPES);
+
+    if (!hasType) {
+      return;
+    }
+
     const proposalMessage = validateProposalMessage(
       message as ProposalMessageData
     );
-
     const hasStatus = hasTriggeringStatus(proposalMessage, triggeringStatuses);
-    const hasType = hasTriggeringType(type, EVENT_TYPES);
 
-    if (hasStatus && hasType) {
+    if (hasStatus) {
       createChatroom(proposalMessage);
     }
   };

--- a/src/queue/consumers/scicat/scicatProposal/consumers/ChatroomCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/ChatroomCreationQueueConsumer.ts
@@ -32,13 +32,16 @@ export class ChatroomCreationQueueConsumer extends QueueConsumer {
       return;
     }
 
+    const hasStatus = hasTriggeringStatus(message, triggeringStatuses);
+
+    if (!hasStatus) {
+      return;
+    }
+
     const proposalMessage = validateProposalMessage(
       message as ProposalMessageData
     );
-    const hasStatus = hasTriggeringStatus(proposalMessage, triggeringStatuses);
 
-    if (hasStatus) {
-      createChatroom(proposalMessage);
-    }
+    createChatroom(proposalMessage);
   };
 }

--- a/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.spec.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.spec.ts
@@ -1,4 +1,3 @@
-jest.mock('../../../utils/validateMessages');
 jest.mock('../../../utils/hasTriggeringStatus');
 jest.mock('../../../utils/hasTriggeringType');
 jest.mock('../../../QueueConsumer', () => ({
@@ -12,29 +11,57 @@ import { MessageBroker } from '@user-office-software/duo-message-broker';
 import { FolderCreationQueueConsumer } from './FolderCreationQueueConsumer';
 import { hasTriggeringStatus } from '../../../utils/hasTriggeringStatus';
 import { hasTriggeringType } from '../../../utils/hasTriggeringType';
-import { validateProposalMessage } from '../../../utils/validateMessages';
 
 describe('FolderCreationQueueConsumer', () => {
-  it.each([
-    [false, false],
-    [false, true],
-    [true, false],
-  ])(
-    'should not throw error when message does not have the correct type or status',
-    (hasStatus, hasType) => {
-      (validateProposalMessage as jest.Mock).mockReturnValueOnce({
-        newStatus: 'newStatus',
-      });
-      (hasTriggeringStatus as jest.Mock).mockReturnValueOnce(hasStatus);
-      (hasTriggeringType as jest.Mock).mockReturnValueOnce(hasType);
+  it('should not throw an error when message does not have the correct type and status', async () => {
+    (hasTriggeringType as jest.Mock).mockReturnValueOnce(false);
+    (hasTriggeringStatus as jest.Mock).mockReturnValueOnce(false);
 
-      const consumer = new FolderCreationQueueConsumer({} as MessageBroker);
+    const consumer = new FolderCreationQueueConsumer({} as MessageBroker);
 
-      expect(() => {
-        consumer.onMessage('type', { message: 'message' }, {
-          headers: {},
-        } as any);
-      }).not.toThrow();
-    }
-  );
+    await expect(
+      consumer.onMessage('type', { message: 'message' }, {
+        headers: {},
+      } as any)
+    ).resolves.not.toThrow();
+  });
+
+  it('should not throw an error when message does have the incorrect type and correct status', async () => {
+    (hasTriggeringType as jest.Mock).mockReturnValueOnce(false);
+    (hasTriggeringStatus as jest.Mock).mockReturnValueOnce(true);
+
+    const consumer = new FolderCreationQueueConsumer({} as MessageBroker);
+
+    await expect(
+      consumer.onMessage('type', { message: 'message' }, {
+        headers: {},
+      } as any)
+    ).resolves.not.toThrow();
+  });
+
+  it('should not throw an error when message does have the correct type and incorrect status', async () => {
+    (hasTriggeringType as jest.Mock).mockReturnValueOnce(true);
+    (hasTriggeringStatus as jest.Mock).mockReturnValueOnce(false);
+
+    const consumer = new FolderCreationQueueConsumer({} as MessageBroker);
+
+    await expect(
+      consumer.onMessage('type', { message: 'message' }, {
+        headers: {},
+      } as any)
+    ).resolves.not.toThrow();
+  });
+
+  it('should throw error when invalid message does have the correct type or status', async () => {
+    (hasTriggeringStatus as jest.Mock).mockReturnValueOnce(true);
+    (hasTriggeringType as jest.Mock).mockReturnValueOnce(true);
+
+    const consumer = new FolderCreationQueueConsumer({} as MessageBroker);
+
+    await expect(
+      consumer.onMessage('type', { message: 'message' }, {
+        headers: {},
+      } as any)
+    ).rejects.toThrow();
+  });
 });

--- a/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.spec.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.spec.ts
@@ -6,9 +6,7 @@ jest.mock('../../../QueueConsumer', () => ({
     start: jest.fn(),
   })),
 }));
-jest.mock('@user-office-software/duo-logger');
 
-import { logger } from '@user-office-software/duo-logger';
 import { MessageBroker } from '@user-office-software/duo-message-broker';
 
 import { FolderCreationQueueConsumer } from './FolderCreationQueueConsumer';
@@ -22,29 +20,21 @@ describe('FolderCreationQueueConsumer', () => {
     [false, true],
     [true, false],
   ])(
-    'should use logError when message does not have the correct type or status',
+    'should not throw error when message does not have the correct type or status',
     (hasStatus, hasType) => {
       (validateProposalMessage as jest.Mock).mockReturnValueOnce({
         newStatus: 'newStatus',
       });
       (hasTriggeringStatus as jest.Mock).mockReturnValueOnce(hasStatus);
       (hasTriggeringType as jest.Mock).mockReturnValueOnce(hasType);
-      const mockLoggerLogError = jest.spyOn(logger, 'logError');
 
       const consumer = new FolderCreationQueueConsumer({} as MessageBroker);
 
-      consumer.onMessage('type', { message: 'message' }, {
-        headers: {},
-      } as any);
-
-      expect(mockLoggerLogError).toHaveBeenCalledTimes(1);
-      expect(mockLoggerLogError).toHaveBeenCalledWith(
-        'Message does not have the correct type or status',
-        {
-          status: 'newStatus',
-          type: 'type',
-        }
-      );
+      expect(() => {
+        consumer.onMessage('type', { message: 'message' }, {
+          headers: {},
+        } as any);
+      }).not.toThrow();
     }
   );
 });

--- a/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.ts
@@ -33,14 +33,16 @@ export class FolderCreationQueueConsumer extends QueueConsumer {
       return;
     }
 
+    const hasStatus = hasTriggeringStatus(message, triggeringStatuses);
+
+    if (!hasStatus) {
+      return;
+    }
+
     const proposalMessage = validateProposalMessage(
       message as ProposalMessageData
     );
 
-    const hasStatus = hasTriggeringStatus(proposalMessage, triggeringStatuses);
-
-    if (hasStatus) {
-      proposalFoldersCreation(proposalMessage);
-    }
+    proposalFoldersCreation(proposalMessage);
   };
 }

--- a/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.ts
@@ -1,4 +1,3 @@
-import { logger } from '@user-office-software/duo-logger';
 import { ConsumerCallback } from '@user-office-software/duo-message-broker';
 
 import { Event } from '../../../../../models/Event';
@@ -27,22 +26,21 @@ export class FolderCreationQueueConsumer extends QueueConsumer {
   }
 
   onMessage: ConsumerCallback = async (arg0, message, properties) => {
+    const type = properties.headers.type || arg0;
+    const hasType = hasTriggeringType(type, EVENT_TYPES);
+
+    if (!hasType) {
+      return;
+    }
+
     const proposalMessage = validateProposalMessage(
       message as ProposalMessageData
     );
 
-    const type = properties.headers.type || arg0;
-
     const hasStatus = hasTriggeringStatus(proposalMessage, triggeringStatuses);
-    const hasType = hasTriggeringType(type, EVENT_TYPES);
 
-    if (hasStatus && hasType) {
+    if (hasStatus) {
       proposalFoldersCreation(proposalMessage);
-    } else {
-      logger.logError('Message does not have the correct type or status', {
-        type: type,
-        status: proposalMessage.newStatus,
-      });
     }
   };
 }

--- a/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/FolderCreationQueueConsumer.ts
@@ -26,7 +26,7 @@ export class FolderCreationQueueConsumer extends QueueConsumer {
   }
 
   onMessage: ConsumerCallback = async (arg0, message, properties) => {
-    const type = properties.headers.type || arg0;
+    const type = properties?.headers?.type || arg0;
     const hasType = hasTriggeringType(type, EVENT_TYPES);
 
     if (!hasType) {

--- a/src/queue/consumers/scicat/scicatProposal/consumers/ProposalCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/ProposalCreationQueueConsumer.ts
@@ -32,14 +32,16 @@ export class ProposalCreationQueueConsumer extends QueueConsumer {
       return;
     }
 
+    const hasStatus = hasTriggeringStatus(message, triggeringStatuses);
+
+    if (!hasStatus) {
+      return;
+    }
+
     const proposalMessage = validateProposalMessage(
       message as ProposalMessageData
     );
 
-    const hasStatus = hasTriggeringStatus(proposalMessage, triggeringStatuses);
-
-    if (hasStatus) {
-      upsertProposalInScicat(proposalMessage);
-    }
+    upsertProposalInScicat(proposalMessage);
   };
 }

--- a/src/queue/consumers/scicat/scicatProposal/consumers/ProposalCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/ProposalCreationQueueConsumer.ts
@@ -26,14 +26,19 @@ export class ProposalCreationQueueConsumer extends QueueConsumer {
   }
 
   onMessage: ConsumerCallback = async (type, message) => {
+    const hasType = hasTriggeringType(type, EVENT_TYPES);
+
+    if (!hasType) {
+      return;
+    }
+
     const proposalMessage = validateProposalMessage(
       message as ProposalMessageData
     );
 
     const hasStatus = hasTriggeringStatus(proposalMessage, triggeringStatuses);
-    const hasType = hasTriggeringType(type, EVENT_TYPES);
 
-    if (hasStatus && hasType) {
+    if (hasStatus) {
       upsertProposalInScicat(proposalMessage);
     }
   };

--- a/src/queue/consumers/utils/hasTriggeringStatus.ts
+++ b/src/queue/consumers/utils/hasTriggeringStatus.ts
@@ -1,7 +1,5 @@
-import { ProposalMessageData } from '../../../models/ProposalMessage';
-
 export const hasTriggeringStatus = (
-  message: ProposalMessageData,
+  message: any,
   statuses: string[] | undefined
 ) => {
   if (!message.newStatus || !statuses) {

--- a/src/queue/consumers/utils/validateMessages.spec.ts
+++ b/src/queue/consumers/utils/validateMessages.spec.ts
@@ -1,0 +1,30 @@
+import { validateProposalMessage } from './validateMessages';
+
+describe('Validate messages', () => {
+  it('should throw error when message is not valid', () => {
+    expect(() =>
+      validateProposalMessage({ message: 'message' } as any)
+    ).toThrow();
+  });
+
+  it('should not throw error when message is valid', () => {
+    expect(() =>
+      validateProposalMessage({
+        title: 'Test proposal',
+        abstract: 'Test abstract',
+        members: [],
+        proposalPk: 1,
+        shortCode: '123123',
+        instrument: { id: 1, shortCode: 'TEST' },
+        newStatus: 'REVIEW',
+        proposer: {
+          id: 1,
+          firstName: 'Test',
+          lastName: 'User',
+          email: 'test.user@email.com',
+          oidcSub: 'testOidcSub',
+        },
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR aims to reduce the unnecessary error logs when we don't have any of the matching event types or proposal statuses.

## Motivation and Context

Connector was generating error logs that were false positives.

## How Has This Been Tested

- unit tests
- manual tests

## Fixes

https://jira.esss.lu.se/browse/SWAP-3809

## Changes

Move the checks of matching event type and status before message content validation.

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
