### PR TITLE
update: use own message validator in 1IM integration queue consumer

### DIFF
--- a/src/queue/consumers/oneidentity/OneIdentityIntegrationQueueConsumer.spec.ts
+++ b/src/queue/consumers/oneidentity/OneIdentityIntegrationQueueConsumer.spec.ts
@@ -44,7 +44,7 @@ describe('OneIdentityIntegrationQueueConsumer', () => {
 
       await expect(
         consumer.onMessage(type, message, {} as MessageProperties)
-      ).rejects.toThrow('Proposal title is missing');
+      ).rejects.toThrow('Invalid proposal message');
     });
 
     it('should call oneIdentityIntegrationHandler and log message handled', async () => {
@@ -108,12 +108,9 @@ describe('OneIdentityIntegrationQueueConsumer', () => {
     memberEmails: string[];
   }): ProposalMessageData {
     return {
-      title: 'title',
       shortCode,
       proposer: { email: proposerEmail, firstName: 'first', lastName: 'last' },
       members: memberEmails.map((email) => ({ email })),
-      abstract: 'abstract',
-      instruments: [{ id: 1, shortCode: 'instrument', allocatedTime: 1 }],
     } as ProposalMessageData;
   }
 });

--- a/src/queue/consumers/oneidentity/OneIdentityIntegrationQueueConsumer.ts
+++ b/src/queue/consumers/oneidentity/OneIdentityIntegrationQueueConsumer.ts
@@ -2,10 +2,10 @@ import { logger } from '@user-office-software/duo-logger';
 import { ConsumerCallback } from '@user-office-software/duo-message-broker';
 
 import { oneIdentityIntegrationHandler } from './consumerCallbacks/oneIdentityIntegrationHandler';
+import { validateRequiredProposalMessageFields } from './utils/validateRequiredProposalMessageFields';
 import { Event } from '../../../models/Event';
 import { QueueConsumer } from '../QueueConsumer';
 import { hasTriggeringType } from '../utils/hasTriggeringType';
-import { validateProposalMessage } from '../utils/validateProposalMessage';
 
 const ONE_IDENTITY_INTEGRATION_QUEUE_NAME =
   process.env.ONE_IDENTITY_INTEGRATION_QUEUE_NAME || '';
@@ -34,7 +34,7 @@ export class OneIdentityIntegrationQueueConsumer extends QueueConsumer {
     });
 
     try {
-      const proposalMessage = validateProposalMessage(message);
+      const proposalMessage = validateRequiredProposalMessageFields(message);
 
       await oneIdentityIntegrationHandler(proposalMessage, type as Event);
 

--- a/src/queue/consumers/oneidentity/utils/validateRequiredProposalMessageFields.spec.ts
+++ b/src/queue/consumers/oneidentity/utils/validateRequiredProposalMessageFields.spec.ts
@@ -1,0 +1,62 @@
+import { validateRequiredProposalMessageFields } from './validateRequiredProposalMessageFields';
+
+describe('validateRequiredProposalMessageFields', () => {
+  it('should throw an error if message is not an object', () => {
+    const message = 'not an object';
+
+    expect(() => validateRequiredProposalMessageFields(message)).toThrow(
+      'Invalid proposal message'
+    );
+  });
+
+  it('should throw an error if message is null', () => {
+    const message = null;
+
+    expect(() => validateRequiredProposalMessageFields(message)).toThrow(
+      'Invalid proposal message'
+    );
+  });
+
+  it('should throw an error if shortCode is undefined', () => {
+    const message = {
+      proposer: {},
+      members: [],
+    };
+
+    expect(() => validateRequiredProposalMessageFields(message)).toThrow(
+      'Invalid proposal message'
+    );
+  });
+
+  it('should throw an error if proposer is undefined', () => {
+    const message = {
+      shortCode: 'shortCode',
+      members: [],
+    };
+
+    expect(() => validateRequiredProposalMessageFields(message)).toThrow(
+      'Invalid proposal message'
+    );
+  });
+
+  it('should throw an error if members is undefined', () => {
+    const message = {
+      shortCode: 'shortCode',
+      proposer: {},
+    };
+
+    expect(() => validateRequiredProposalMessageFields(message)).toThrow(
+      'Invalid proposal message'
+    );
+  });
+
+  it('should return the message if shortCode, proposer, and members are defined', () => {
+    const message = {
+      shortCode: 'shortCode',
+      proposer: {},
+      members: [],
+    };
+
+    expect(validateRequiredProposalMessageFields(message)).toEqual(message);
+  });
+});

--- a/src/queue/consumers/oneidentity/utils/validateRequiredProposalMessageFields.ts
+++ b/src/queue/consumers/oneidentity/utils/validateRequiredProposalMessageFields.ts
@@ -1,0 +1,18 @@
+import { ProposalMessageData } from '../../../../models/ProposalMessage';
+
+// For OneIdentity, only these fields are required
+export function validateRequiredProposalMessageFields(
+  message: any
+): ProposalMessageData | never {
+  if (
+    typeof message !== 'object' ||
+    message === null ||
+    message?.shortCode === undefined ||
+    message?.proposer === undefined ||
+    message?.members === undefined
+  ) {
+    throw new Error('Invalid proposal message');
+  }
+
+  return message as ProposalMessageData;
+}

--- a/src/queue/consumers/utils/validateProposalMessage.ts
+++ b/src/queue/consumers/utils/validateProposalMessage.ts
@@ -33,7 +33,7 @@ export function validateProposalMessage(
     throw new Error('Proposal short code is missing');
   }
 
-  if (!proposalMessage.instruments.length) {
+  if (!proposalMessage.instruments?.length) {
     throw new Error('Instruments are missing');
   }
 


### PR DESCRIPTION
## Description

Update the 1IM integration queue consumer to utilize its own message validator. This validator will validate only the fields that are required during the handling process.

## Motivation and Context

The current general proposal message validator checks unnecessary fields within the consumer's scope. This change aims to streamline the validation process by focusing solely on the required fields.

## How Has This Been Tested

- Unit test