### PR TITLE
fix: Saving oidc sub in the ID column instead of Email to maintain uniqueness

### DIFF
--- a/src/datasources/visa/postgres/UserDataSource.ts
+++ b/src/datasources/visa/postgres/UserDataSource.ts
@@ -19,7 +19,7 @@ export default class PostgresUserDataSource implements UserDataSource {
     if (!user.email || !user.institution) return null;
     const userExists = await database(this.TABLE_NAME)
       .where({
-        id: user.email,
+        email: user.email,
       })
       .first()
       .then((user: UserRecord) => {
@@ -70,7 +70,7 @@ export default class PostgresUserDataSource implements UserDataSource {
       // Insert into users table
       return await database(this.TABLE_NAME)
         .insert({
-          id: user.email,
+          id: user.oidcSub,
           email: user.email,
           first_name: user.firstName ?? '',
           last_name: user.lastName ?? '',


### PR DESCRIPTION
Saving oidc sub in the ID column instead of Email to maintain uniqueness

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Saving email as the unique identifier in the User Primary Column is not scalable and error prone. 

## Motivation and Context

Improve integrity of the data

## How Has This Been Tested

Manually

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
