### PR TITLE
fix: generalize user's oidcSub and make it lowercase

### DIFF
--- a/src/services/synapse/SynapseService.spec.ts
+++ b/src/services/synapse/SynapseService.spec.ts
@@ -87,7 +87,7 @@ describe('SynapseService', () => {
         new AxiosError(validReason)
       );
 
-      const result = await synapseService.getUserByOidcSub(member);
+      const result = await synapseService.getUserByOidcSub(member.oidcSub);
 
       expect(mockLoggerLogError).not.toHaveBeenCalledWith(
         'Not able to find user by oidc_sub',
@@ -104,7 +104,7 @@ describe('SynapseService', () => {
         new AxiosError(InvalidReason)
       );
 
-      const result = await synapseService.getUserByOidcSub(member);
+      const result = await synapseService.getUserByOidcSub(member.oidcSub);
 
       expect(mockLoggerLogError).toHaveBeenCalledWith(
         'Not able to find user by oidc_sub',

--- a/src/services/synapse/SynapseService.ts
+++ b/src/services/synapse/SynapseService.ts
@@ -186,11 +186,11 @@ export class SynapseService {
 
     return response.rooms;
   }
-  async getUserByOidcSub(member: ProposalUser) {
+  async getUserByOidcSub(oidcSub: string) {
     const result = await this.client.http
       .authedRequest<UserId>(
         Method.Get,
-        `/auth_providers/${oauthIssuer}/users/${member.oidcSub}`,
+        `/auth_providers/${oauthIssuer}/users/${oidcSub}`,
         {},
         undefined,
         {
@@ -289,7 +289,7 @@ export class SynapseService {
 
   async userExists(member: ProposalUser) {
     const userExists =
-      !!(await this.getUserByOidcSub(member)) ||
+      !!(await this.getUserByOidcSub(member.oidcSub)) ||
       !!(await this.getUserByEmail(member.email));
 
     if (!userExists) {

--- a/src/services/synapse/produceSynapseUserId.spec.ts
+++ b/src/services/synapse/produceSynapseUserId.spec.ts
@@ -1,13 +1,34 @@
+const serverName = (process.env.SYNAPSE_SERVER_NAME = 'test-server');
+
 import { produceSynapseUserId } from './produceSynapseUserId';
-test('Should produce valid user id', async () => {
-  const member = {
-    id: 1,
-    email: 'john.doe@example.com',
-    firstName: 'John',
-    lastName: 'Doe',
-    oidcSub: '1234',
-    oauthIssuer: 'keycloack',
+
+const member = {
+  id: 1,
+  email: 'john.doe@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  oidcSub: 'test-1234',
+  oauthIssuer: 'keycloack',
+};
+
+test('Should produce valid user id with prefix', async () => {
+  const result = await produceSynapseUserId(member, undefined, false);
+  expect(result).toBe(`@${member.oidcSub}:${serverName}`);
+});
+
+test('Should produce valid user id without prefix', async () => {
+  const result = await produceSynapseUserId(member, undefined, true);
+  expect(result).toBe(`${member.oidcSub}`);
+});
+
+test('Should produce valid user id with special characters', async () => {
+  const memberWithSpecialCharsInOidcSub = {
+    ...member,
+    oidcSub: 'SomeSpecialCharsà',
   };
-  const result = await produceSynapseUserId(member);
-  expect(result).toBe('@1234:serverName');
+  const expectedOidcSub = 'somespecialcharsa';
+
+  const result = await produceSynapseUserId(memberWithSpecialCharsInOidcSub);
+
+  expect(result).toBe(`@${expectedOidcSub}:${serverName}`);
 });

--- a/src/services/synapse/produceSynapseUserId.ts
+++ b/src/services/synapse/produceSynapseUserId.ts
@@ -24,22 +24,14 @@ export async function produceSynapseUserId(
   };
 
   if (synapseService) {
-    const userByOidcSub = await synapseService.getUserByOidcSub(
-      normalizedMember.oidcSub
-    );
-    const userByEmail = await synapseService.getUserByEmail(
-      normalizedMember.email
-    );
+    const user =
+      (await synapseService.getUserByOidcSub(normalizedMember.oidcSub)) ||
+      (await synapseService.getUserByEmail(normalizedMember.email));
 
-    if (userByOidcSub) {
+    if (user) {
       return skipPrePostfix
-        ? userByOidcSub.user_id.replace(/^@|:ess$/g, '')
-        : userByOidcSub.user_id;
-    }
-    if (userByEmail) {
-      return skipPrePostfix
-        ? userByEmail.user_id.replace(/^@|:ess$/g, '')
-        : userByEmail.user_id;
+        ? user.user_id.replace(/^@|:ess$/g, '')
+        : user.user_id;
     }
   }
 


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description
This refactoring improves the clarity and reliability of user ID generation in Synapse-related services.

- Refactored getUserByOidcSub: Changed the method to accept oidcSub directly instead of the entire member object. Updated corresponding method calls in the code and tests.

- Normalized oidcSub: Introduced normalizedMember to handle special characters and lowercase conversion of oidcSub, ensuring it’s a valid Synapse user ID. Updated method calls and test cases accordingly.

- Enhanced Tests: Added and modified test cases to cover scenarios with and without prefixes, and special characters in oidcSub. Adjusted expectations to match the new normalized format.


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
