### PR TITLE
feat: remove users not in updated proposal from room

### DIFF
--- a/src/services/synapse/SynapseService.spec.ts
+++ b/src/services/synapse/SynapseService.spec.ts
@@ -17,15 +17,24 @@ import { SynapseService } from './SynapseService';
 describe('SynapseService', () => {
   let synapseService: SynapseService;
   let mockLoggerLogError: jest.SpyInstance;
+  let mockLoggerLogInfo: jest.SpyInstance;
 
-  const roomId = 'randomId';
+  const serviceAccountSynapseId = `@${process.env.SYNAPSE_SERVICE_USER}:${process.env.SYNAPSE_SERVER_NAME}`;
+  const roomId = '!randomRoom:ess';
   const member = {
     id: 1111,
     email: 'john.doe@example.com',
     firstName: 'John',
     lastName: 'Doe',
-    oidcSub: '1234',
+    oidcSub: 'john.doe',
     oauthIssuer: 'oidc-ping',
+  };
+  const joinedRoomMembers = {
+    joined: {
+      ['user1']: { display_name: 'User1' },
+      ['john.doe']: { display_name: 'John Doe' },
+      [serviceAccountSynapseId]: { display_name: 'ServiceAccount' },
+    },
   };
   const synapseUser = {
     name: '@user:example.com',
@@ -54,22 +63,39 @@ describe('SynapseService', () => {
   };
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
     (createClient as jest.Mock).mockReturnValue(mockCreateClient);
     mockLoggerLogError = jest.spyOn(logger, 'logError');
+    mockLoggerLogInfo = jest.spyOn(logger, 'logInfo');
+    process.env.SYNAPSE_SERVICE_USER = 'serviceUser';
+    process.env.SYNAPSE_SERVER_NAME = 'matrix.org';
     synapseService = new SynapseService();
   });
 
   describe('invite', () => {
-    const validReason = `@${member.id}:ess already in the room`;
+    const validReason = `@${member.oidcSub}:ess already in the room`;
     const InvalidReason = 'invalid reason';
+    const memberToBeRemoved = {
+      id: 1112,
+      email: 'user1@example.com',
+      firstName: 'user1',
+      lastName: 'test',
+      oidcSub: 'user1',
+      oauthIssuer: 'oidc-ping',
+    };
 
     it("should not log any errors when the reason message includes 'already in the room", async () => {
-      (produceSynapseUserId as jest.Mock).mockResolvedValue(member.id);
+      const joinedRoomMembersSet = new Set('');
+      jest
+        .spyOn(synapseService, 'getRoomMembers')
+        .mockResolvedValueOnce(joinedRoomMembersSet);
+
+      (produceSynapseUserId as jest.Mock).mockResolvedValueOnce(member.oidcSub);
 
       mockCreateClient.http.authedRequest.mockRejectedValueOnce(
         new AxiosError(validReason)
       );
+
       const result = await synapseService.invite(roomId, [member]);
 
       expect(mockLoggerLogError).not.toHaveBeenCalledWith(
@@ -79,21 +105,62 @@ describe('SynapseService', () => {
           member: member,
         }
       );
-      expect(result[0]).toEqual({ invited: false, userId: member.id });
+      expect(result[0]).toEqual({ invited: false, userId: member.oidcSub });
     });
     it("should log errors when the reason message does not include 'already in the room'", async () => {
-      (produceSynapseUserId as jest.Mock).mockResolvedValue(member.id);
+      const joinedRoomMembersSet = new Set('');
+      jest
+        .spyOn(synapseService, 'getRoomMembers')
+        .mockResolvedValueOnce(joinedRoomMembersSet);
+
+      (produceSynapseUserId as jest.Mock).mockResolvedValueOnce(member.oidcSub);
 
       mockCreateClient.http.authedRequest.mockRejectedValueOnce(
         new AxiosError(InvalidReason)
       );
+
       const result = await synapseService.invite(roomId, [member]);
 
       expect(mockLoggerLogError).toHaveBeenCalledWith('Failed to invite user', {
         message: InvalidReason,
         member: member,
       });
-      expect(result[0]).toEqual({ invited: false, userId: member.id });
+      expect(result[0]).toEqual({ invited: false, userId: member.oidcSub });
+    });
+
+    it('should remove the user from the chatroom if the updated proposal does not include the previous member in the room', async () => {
+      const joinedRoomMembersSet = new Set(
+        Object.keys(joinedRoomMembers.joined)
+      );
+
+      jest
+        .spyOn(synapseService, 'getRoomMembers')
+        .mockResolvedValueOnce(joinedRoomMembersSet);
+
+      const removeUserFromRoomSpy = jest
+        .spyOn(synapseService, 'removeUserFromRoom')
+        .mockResolvedValueOnce();
+
+      (produceSynapseUserId as jest.Mock)
+        .mockResolvedValueOnce(member.oidcSub)
+        .mockResolvedValueOnce(memberToBeRemoved.oidcSub);
+
+      mockCreateClient.http.authedRequest
+        .mockResolvedValueOnce('/rooms/${roomId}/joined_members Call')
+        .mockResolvedValueOnce('/join/${roomId} Call')
+        .mockResolvedValueOnce('/rooms/${roomId}/kick Call');
+
+      const result = await synapseService.invite(roomId, [member]);
+
+      expect(removeUserFromRoomSpy).toHaveBeenCalledWith(
+        roomId,
+        memberToBeRemoved.oidcSub
+      );
+      expect(result).toEqual([{ userId: member.oidcSub, invited: true }]);
+      expect(result).not.toContainEqual({
+        userId: memberToBeRemoved.oidcSub,
+        invited: true,
+      });
     });
   });
 
@@ -201,6 +268,78 @@ describe('SynapseService', () => {
       );
 
       expect(result).toEqual(undefined);
+    });
+  });
+
+  describe('getRoomMembers', () => {
+    const unknownError = 'unknown Error';
+
+    it('should get all the members from the room except the service account', async () => {
+      mockCreateClient.http.authedRequest.mockResolvedValueOnce(
+        joinedRoomMembers
+      );
+      const result = await synapseService.getRoomMembers(roomId);
+
+      const noServiceAccount = new Set(Object.keys(joinedRoomMembers.joined));
+      noServiceAccount.delete(serviceAccountSynapseId);
+
+      expect(result).toEqual(noServiceAccount);
+    });
+
+    it('should log errors if the room members are not retrievable', async () => {
+      mockCreateClient.http.authedRequest.mockRejectedValueOnce(
+        new AxiosError(unknownError)
+      );
+
+      await expect(synapseService.getRoomMembers(roomId)).rejects.toThrow(
+        unknownError
+      );
+
+      expect(mockLoggerLogError).toHaveBeenCalledWith(
+        'Failed to get joined room members',
+        {
+          reason: new AxiosError(unknownError),
+          roomId,
+        }
+      );
+    });
+  });
+
+  describe('removeUserFromRoom', () => {
+    const unknownError = 'unknown Error';
+    const userId = 'user1';
+
+    it('should remove a user from the room', async () => {
+      mockCreateClient.http.authedRequest.mockResolvedValueOnce({
+        roomId,
+        userId,
+      });
+
+      await synapseService.removeUserFromRoom(roomId, userId);
+
+      expect(mockLoggerLogInfo).toHaveBeenCalledWith('Removed user from room', {
+        roomId,
+        userId,
+      });
+    });
+
+    it('should log errors if the user cannot be removed from the room', async () => {
+      mockCreateClient.http.authedRequest.mockRejectedValueOnce(
+        new AxiosError(unknownError)
+      );
+
+      await expect(
+        synapseService.removeUserFromRoom(roomId, userId)
+      ).rejects.toThrow(unknownError);
+
+      expect(mockLoggerLogError).toHaveBeenCalledWith(
+        'Failed to remove user from room',
+        {
+          message: unknownError,
+          roomId,
+          userId,
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Ensure users not included in the updated proposal are removed from the room. Added logic to fetch room members, identify users to be removed, and remove them via the Synapse API

<img width="450" alt="image" src="https://github.com/user-attachments/assets/8882d404-31bc-4ef8-bcd1-c28ff61227c8">

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
