### PR TITLE
fix: get user email with lower case

### DIFF
--- a/src/services/synapse/SynapseService.ts
+++ b/src/services/synapse/SynapseService.ts
@@ -222,10 +222,11 @@ export class SynapseService {
   }
 
   async getUserByEmail(email: string) {
+    const lowerCaseEmail = email.toLowerCase();
     const result = await this.client.http
       .authedRequest<UserId>(
         Method.Get,
-        `/threepid/${thirdPartyId}/users/${email}`,
+        `/threepid/${thirdPartyId}/users/${lowerCaseEmail}`,
         {},
         undefined,
         {


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

Synapse getUserByEmail method does not get user when the user's email contain upper case

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
