### PR TITLE
chore: add auto-merge workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto approve and merge
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+  packages: read
+
+jobs:
+  auto-approve-and-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      # Extract information about the dependencies being updated by a Dependabot-generated PR
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # NOTE: This step is only required if the repository has been configured to Require approval
+      # Checks if update-type is patch or minor, then approve if the PR status is not approved yet.
+      - name: Auto approve patch and minor updates
+        uses: hmarr/auto-approve-action@v4
+        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
+      
+      # NOTE: Requirements for merge has to be configured in the Branch protection rule page.
+      # To do so, go to repository > Settings > Branches > Edit
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ contains(github.event.pull_request.title, 'bump')}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This commit adds a new workflow file, auto-merge-dependabot.yml, which enables automatic approval and merging of Dependabot-generated pull requests. The workflow checks if the PR is generated by the Dependabot bot and if the update type is either a patch or a minor version update. If these conditions are met, the workflow automatically approves the PR and merges it. This workflow is triggered on pull requests and requires specific permissions for pull requests, contents, and packages.