### PR TITLE
fix: orcid lowercasing done

### DIFF
--- a/src/queue/consumers/visa/consumers/syncProposalQueueConsumer.ts
+++ b/src/queue/consumers/visa/consumers/syncProposalQueueConsumer.ts
@@ -2,11 +2,13 @@ import { logger } from '@user-office-software/duo-logger';
 import { ConsumerCallback } from '@user-office-software/duo-message-broker';
 
 import { Event } from '../../../../models/Event';
+import { ProposalMessageData } from '../../../../models/ProposalMessage';
 import { QueueConsumer } from '../../QueueConsumer';
 import { hasTriggeringStatus } from '../../utils/hasTriggeringStatus';
 import { hasTriggeringType } from '../../utils/hasTriggeringType';
 import { validateProposalMessage } from '../../utils/validateProposalMessage';
 import { syncVisaProposal } from '../consumerCallbacks/syncVisaProposal';
+import { sanitizeProposalMessage } from '../utils/sanitizeProposalMessage';
 
 const EVENTS_FOR_HANDLING = [
   Event.PROPOSAL_STATUS_CHANGED_BY_WORKFLOW,
@@ -40,7 +42,10 @@ export class SyncProposalQueueConsumer extends QueueConsumer {
     if (!hasStatus) {
       return;
     }
-    const proposalMessage = validateProposalMessage(message);
+
+    const proposalMessage = validateProposalMessage(
+      sanitizeProposalMessage(message as ProposalMessageData)
+    );
 
     await syncVisaProposal(proposalMessage);
   };

--- a/src/queue/consumers/visa/utils/sanitizeProposalMessage.ts
+++ b/src/queue/consumers/visa/utils/sanitizeProposalMessage.ts
@@ -1,0 +1,21 @@
+import { ProposalMessageData } from '../../../../models/ProposalMessage';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export function sanitizeProposalMessage(proposalMessage: ProposalMessageData) {
+  return {
+    ...proposalMessage,
+    members: proposalMessage.members.map((member) => ({
+      ...member,
+      oidcSub: member.oidcSub.toLowerCase(),
+      email: member.email.toLowerCase(),
+    })),
+    proposer: proposalMessage.proposer
+      ? {
+          ...proposalMessage.proposer,
+          oidcSub: proposalMessage.proposer.oidcSub.toLowerCase(),
+          email: proposalMessage.proposer.email,
+        }
+      : undefined,
+  };
+}


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

In the Visa connector, when creating experiment users, lower the case of orcid and email before saving into the users table

## Motivation and Context

During the Visa login, which is using keycloack, the username is being lowercased. However, the username from the user office proposal doesnt. Due to this, the logged in user could not see their corresponding proposals. This can be fixed by lowercasing the username during the acceptance of the proposal

## How Has This Been Tested

Manual
## Fixes

User not able to see their proposal in the Visa

## Changes

Added a sanitizing function, that transforms the entire payload based on the requirements. 

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated

## Summary by Sourcery

Lowercase ORCID and email addresses in proposal messages to ensure consistency and fix visibility issues for users.

Bug Fixes:
- Fix issue where users could not see their proposals by lowercasing ORCID and email addresses before saving them.

Enhancements:
- Add a sanitizing function to transform the proposal message payload by lowercasing ORCID and email addresses.