### PR TITLE
chore: update duo-message-broker dependency to version 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@user-office-software/duo-logger": "^2.2.1",
-        "@user-office-software/duo-message-broker": "^1.6.0",
+        "@user-office-software/duo-message-broker": "^1.7.0",
         "axios": "^1.7.7",
         "dotenv": "^16.4.5",
         "envalid": "^8.0.0",
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/@user-office-software/duo-message-broker": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.6.0.tgz",
-      "integrity": "sha512-sdU9qi23WoPOP8W+H3eF9qM5fdqQBtT3/nN+y0jFUykrA1vG25ZfEW1bC9sVWwBoofhGpnewi58IUngghdsg4A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.7.0.tgz",
+      "integrity": "sha512-OK8PhXxvNlR/PFugrVr1SYPkGZvgPmDMcSSxeC6cGVsSmLSvXYzz0YKoa8zblxPwXPcWC77yy4gPGb7jIzq1cg==",
       "dependencies": {
         "@types/amqplib": "^0.10.1",
         "@user-office-software/duo-logger": "^2.1.1",
@@ -10307,9 +10307,9 @@
       }
     },
     "@user-office-software/duo-message-broker": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.6.0.tgz",
-      "integrity": "sha512-sdU9qi23WoPOP8W+H3eF9qM5fdqQBtT3/nN+y0jFUykrA1vG25ZfEW1bC9sVWwBoofhGpnewi58IUngghdsg4A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.7.0.tgz",
+      "integrity": "sha512-OK8PhXxvNlR/PFugrVr1SYPkGZvgPmDMcSSxeC6cGVsSmLSvXYzz0YKoa8zblxPwXPcWC77yy4gPGb7jIzq1cg==",
       "requires": {
         "@types/amqplib": "^0.10.1",
         "@user-office-software/duo-logger": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@user-office-software/duo-logger": "^2.2.1",
-    "@user-office-software/duo-message-broker": "^1.6.0",
+    "@user-office-software/duo-message-broker": "^1.7.0",
     "axios": "^1.7.7",
     "dotenv": "^16.4.5",
     "envalid": "^8.0.0",

--- a/src/queue/messageBroker/getMockMessageBroker.ts
+++ b/src/queue/messageBroker/getMockMessageBroker.ts
@@ -37,7 +37,7 @@ class MockMessageBroker implements MessageBroker {
   sendBroadcast(queue: Queue, type: string, message: string): Promise<void> {
     throw new Error('Method not implemented.');
   }
-  listenOn(queue: Queue, cb: ConsumerCallback): void {
+  listenOn(queue: Queue, cb: ConsumerCallback): Promise<void> {
     throw new Error('Method not implemented.');
   }
   listenOnBroadcast(cb: ConsumerCallback): void {


### PR DESCRIPTION
The new version of duo-message-broker package brings several minor changes to the interface, therefore, the mock has been updated accordingly.

## Summary by Sourcery

Update the duo-message-broker dependency to version 1.7.0 and adjust the mock implementation to accommodate interface changes in the new version.

Enhancements:
- Modify the mock implementation to align with the updated interface of duo-message-broker version 1.7.0.

Chores:
- Update duo-message-broker dependency to version 1.7.0.