### PR TITLE
fix: change fallback value of JSON.parse to string

### DIFF
--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
@@ -151,7 +151,7 @@ const checkProposalExists = async (
       Authorization: `Bearer ${sciCatAccessToken}`,
     },
   }).catch((error) => {
-    const parsedError = JSON.parse(error.message || {});
+    const parsedError = JSON.parse(error.message || '{}');
     if (parsedError.statusCode === 404) {
       return false;
     }


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated

## Summary by Sourcery

Bug Fixes:
- Change the fallback value of JSON.parse from an empty object to an empty string in error handling.