### PR TITLE
fix: improve error handling in checkProposalExists function

### DIFF
--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.spec.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/proposalFoldersCreation.spec.ts
@@ -85,7 +85,7 @@ describe('proposalFoldersCreation', () => {
 
     expect(exec).toHaveBeenCalledTimes(1);
     expect(exec).toHaveBeenCalledWith(
-      'command shortcode 2024 shortCode group_prefix_shortCode test.proposer@email.com test.member@email.com',
+      'command shortcode 2025 shortCode group_prefix_shortCode test.proposer@email.com test.member@email.com',
       expect.any(Function)
     );
   });

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
@@ -151,9 +151,13 @@ const checkProposalExists = async (
       Authorization: `Bearer ${sciCatAccessToken}`,
     },
   }).catch((error) => {
-    const parsedError = JSON.parse(error.message || '{}');
-    if (parsedError.statusCode === 404) {
-      return false;
+    try {
+      const parsedError = JSON.parse(error.message);
+      if (parsedError.statusCode === 404) {
+        return false;
+      }
+    } catch (reason) {
+      logger.logError('Error parsing error message', { reason });
     }
     throw error;
   });

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
@@ -157,7 +157,10 @@ const checkProposalExists = async (
         return false;
       }
     } catch (reason) {
-      logger.logError('Error parsing error message', { reason });
+      logger.logError('Error parsing error message', {
+        error,
+        reason,
+      });
     }
     throw error;
   });


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

The change now checks if the error.message is parsable before attempting to parse it. If parsing fails, it logs the raw error instead.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
