### PR TITLE
chore: upgrade Node.js version to 22 in Dockerfiles and update engine requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS build-stage
+FROM node:22-alpine AS build-stage
 
 USER node
 
@@ -14,7 +14,7 @@ COPY --chown=node:node . .
 
 RUN npm run build
 
-FROM node:18-alpine
+FROM node:22-alpine
 
 USER node
 

--- a/Dockerfile.connector.dev
+++ b/Dockerfile.connector.dev
@@ -1,0 +1,11 @@
+FROM node:22-alpine
+
+USER node
+
+RUN mkdir -p /home/node/app
+
+WORKDIR /home/node/app
+
+COPY --chown=node:node package*.json ./
+
+RUN npm ci --loglevel error --no-fund

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The connector connects other services through the message queue.
 
 # Requirements
-This service requires node =>18.0.0
+This service requires node =>22.0.0
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The connector connects other services through the message queue.
 
 # Requirements
-This service requires node =>22.0.0
+This service requires node >=22.0.0
 
 ## Getting started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,8 +46,8 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "service"
   ],
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.0.0",
+    "node": ">=22.0.0"
   },
   "author": "SIMS",
   "license": "MIT",


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the project to use Node.js version 22 by updating the Dockerfiles and engine requirements in package.json.

Build:
- Update the base Node.js version in the Dockerfiles to version 22.

Documentation:
- Update the required Node.js version in the README to reflect the new minimum version.