### PR TITLE
refactor: replace email with oidcSub in One Identity integration

### DIFF
--- a/src/queue/consumers/oneidentity/consumerCallbacks/oneIdentityIntegrationHandler.spec.ts
+++ b/src/queue/consumers/oneidentity/consumerCallbacks/oneIdentityIntegrationHandler.spec.ts
@@ -40,11 +40,11 @@ const setupMocks = (data: {
   mockOneIdentity.getPersons.mockResolvedValueOnce(
     data.getPersons ?? [
       {
-        email: 'proposer@email',
+        oidcSub: 'proposer-oidc-sub',
         uidPerson: 'proposer-uid',
       },
       {
-        email: 'member@email',
+        oidcSub: 'member-oidc-sub',
         uidPerson: 'member-uid',
       },
     ]
@@ -53,8 +53,8 @@ const setupMocks = (data: {
 
 const proposalMessage = {
   shortCode: 'shortCode',
-  proposer: { email: 'proposer@email' },
-  members: [{ email: 'member@email' }],
+  proposer: { oidcSub: 'proposer-oidc-sub' },
+  members: [{ oidcSub: 'member-oidc-sub' }],
 } as ProposalMessageData;
 
 describe('oneIdentityIntegrationHandler', () => {
@@ -104,7 +104,7 @@ describe('oneIdentityIntegrationHandler', () => {
         getProposalPersonConnections: [],
         getPersons: [
           {
-            email: 'proposer@email',
+            oidcSub: 'proposer-oidc-sub',
             uidPerson: 'proposer-uid',
           },
         ],
@@ -118,7 +118,10 @@ describe('oneIdentityIntegrationHandler', () => {
       expect(logger.logError).toHaveBeenCalledWith(
         'Not all users found in One Identity (investigate)',
         {
-          users: [{ email: 'member@email' }, { email: 'proposer@email' }],
+          users: [
+            { oidcSub: 'member-oidc-sub' },
+            { oidcSub: 'proposer-oidc-sub' },
+          ],
           uidPersons: ['proposer-uid'],
         }
       );

--- a/src/queue/consumers/oneidentity/consumerCallbacks/oneIdentityIntegrationHandler.ts
+++ b/src/queue/consumers/oneidentity/consumerCallbacks/oneIdentityIntegrationHandler.ts
@@ -106,7 +106,7 @@ function getUidPersons(
 ): UID_Person[] {
   return userPersonConnections
     .filter(
-      (connection): connection is { email: string; uidPerson: UID_Person } =>
+      (connection): connection is { oidcSub: string; uidPerson: UID_Person } =>
         connection.uidPerson !== undefined
     )
     .map(({ uidPerson }) => uidPerson);

--- a/src/queue/consumers/oneidentity/utils/ESSOneIdentity.spec.ts
+++ b/src/queue/consumers/oneidentity/utils/ESSOneIdentity.spec.ts
@@ -113,18 +113,17 @@ describe('ESSOneIdentity', () => {
       ]);
 
       const result = await essOneIdentity.getPerson({
-        email: 'foo@email',
+        oidcSub: '0000-0000-0000-0000',
       });
 
       expect(mockOneIdentityApi.getEntities).toHaveBeenCalledWith(
         'Person',
-        "ContactEmail='foo@email' OR DefaultEmailAddress='foo@email'"
+        "CentralAccount='0000-0000-0000-0000'"
       );
       expect(result).toEqual({ UID_Person: 'person-uid' });
     });
 
-    // Currently, the ContactEmail field is not unique in the 1IM.Person table.
-    // This means that it is possible to have multiple persons with the same email.
+    // The CentralAccount is unique, but the response is an array of entities
     it('should return the first person if multiple persons are found', async () => {
       mockOneIdentityApi.getEntities.mockResolvedValueOnce([
         {
@@ -140,7 +139,7 @@ describe('ESSOneIdentity', () => {
       ]);
 
       const result = await essOneIdentity.getPerson({
-        email: 'foo@email',
+        oidcSub: '0000-0000-0000-0000',
       });
 
       expect(result).toEqual({ UID_Person: 'person-1-uid' });
@@ -152,8 +151,7 @@ describe('ESSOneIdentity', () => {
       mockOneIdentityApi.getEntities.mockImplementation((table, filter) => {
         if (
           table === 'Person' &&
-          filter ===
-            "ContactEmail='unknown-email' OR DefaultEmailAddress='unknown-email'"
+          filter === "CentralAccount='unknown-oidc-sub'"
         )
           return Promise.resolve([]);
         else
@@ -168,20 +166,20 @@ describe('ESSOneIdentity', () => {
 
       const result = await essOneIdentity.getPersons([
         {
-          email: 'unknown-email',
+          oidcSub: 'unknown-oidc-sub',
         } as ProposalUser,
         {
-          email: 'known-email',
+          oidcSub: 'known-oidc-sub',
         } as ProposalUser,
       ]);
 
       expect(result).toEqual([
         {
-          email: 'unknown-email',
+          oidcSub: 'unknown-oidc-sub',
           uidPerson: undefined,
         },
         {
-          email: 'known-email',
+          oidcSub: 'known-oidc-sub',
           uidPerson: 'known-person-uid',
         },
       ]);

--- a/src/queue/consumers/oneidentity/utils/ESSOneIdentity.ts
+++ b/src/queue/consumers/oneidentity/utils/ESSOneIdentity.ts
@@ -29,7 +29,7 @@ export interface PersonHasESETValues {
 }
 
 export interface UserPersonConnection {
-  email: string;
+  oidcSub: string;
   uidPerson: UID_Person | undefined;
 }
 
@@ -95,15 +95,13 @@ export class ESSOneIdentity {
   }
 
   public async getPerson(
-    user: Pick<ProposalUser, 'email'>
+    user: Pick<ProposalUser, 'oidcSub'>
   ): Promise<PersonValues | undefined> {
     const entities = await this.oneIdentityApi.getEntities<PersonValues>(
       'Person',
-      `ContactEmail='${user.email}' OR DefaultEmailAddress='${user.email}'` // ContactEmail is for scienceusers, DefaultEmailAddress is for ESS employees
+      `CentralAccount='${user.oidcSub}'`
     );
 
-    // In theory there should be only one person with the same email, but the 1IM.Person table has no unique constraint on ContactEmail.
-    // We can't control this, so we just take the first one.
     return entities[0]?.values;
   }
 
@@ -116,7 +114,7 @@ export class ESSOneIdentity {
         .map(async (user) => {
           const uidPerson = (await this.getPerson(user))?.UID_Person;
 
-          return { email: user.email, uidPerson };
+          return { oidcSub: user.oidcSub, uidPerson };
         })
     );
   }


### PR DESCRIPTION
This update replaces the previous email-based user identification with OIDC sub references throughout the One Identity integration. The change updates the mock responses, tests, and real code paths to query users by oidcSub instead of their email addresses. 