### PR TITLE
fix: remove PROPOSAL_STATUS_ACTION_EXECUTED event type from ChatroomCrreationQueueConsumer which is causing multiple scichat room creation

### DIFF
--- a/src/queue/consumers/scicat/scicatProposal/consumers/ChatroomCreationQueueConsumer.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumers/ChatroomCreationQueueConsumer.ts
@@ -10,7 +10,6 @@ import { createChatroom } from '../consumerCallbacks/createChatroom';
 const EVENT_TYPES = [
   Event.PROPOSAL_STATUS_CHANGED_BY_WORKFLOW,
   Event.PROPOSAL_STATUS_CHANGED_BY_USER,
-  Event.PROPOSAL_STATUS_ACTION_EXECUTED,
   Event.PROPOSAL_UPDATED,
 ];
 const triggeringStatuses =


### PR DESCRIPTION

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

The `PROPOSAL_STATUS_ACTION_EXECUTED` event type is causing multiple SciChat room creations due to a message received from the Proposal event via the message broker and an email-sending event triggered for the recipient that happens simultaneously.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the PROPOSAL_STATUS_ACTION_EXECUTED event type was causing multiple SciChat room creations due to simultaneous message broker and email-sending events.