### PR TITLE
feat: Add metadata field to proposal DTOs and implement instruments o…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 npx --no-install lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx lint-staged --shell
+#!/bin/sh
+npx --no-install lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+#!/bin/sh
 npx --no-install lint-staged

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
@@ -1,5 +1,6 @@
 import { logger } from '@user-office-software/duo-logger';
 
+import { Instrument } from '../../../../../models/ProposalMessage';
 import { ValidProposalMessageData } from '../../../utils/validateProposalMessage';
 import { CreateProposalDto, UpdateProposalDto } from '../dto';
 
@@ -64,6 +65,7 @@ const getCreateProposalDto = (proposalMessage: ValidProposalMessageData) => {
     startTime: new Date(),
     endTime: new Date(),
     MeasurementPeriodList: [],
+    metadata: createInstrumentsObject(proposalMessage.instruments),
   };
 
   return createProposalDto;
@@ -84,9 +86,32 @@ const getUpdateProposalDto = (proposalMessage: ValidProposalMessageData) => {
     startTime: new Date(),
     endTime: new Date(),
     MeasurementPeriodList: [],
+    metadata: createInstrumentsObject(proposalMessage.instruments),
   };
 
   return updateProposalDto;
+};
+
+const createInstrumentsObject = (instruments: Instrument[]) => {
+  const instrumentsObject: Record<
+    string,
+    { value: string | number; unit: string }
+  > = {};
+
+  instruments.forEach((instrument, index) => {
+    if (instrument) {
+      instrumentsObject[`instrument_${index + 1}`] = {
+        value: instrument.shortCode,
+        unit: '',
+      };
+      instrumentsObject[`instrument_time_${index + 1}`] = {
+        value: instrument.allocatedTime / 86400,
+        unit: 'days',
+      };
+    }
+  });
+
+  return instrumentsObject;
 };
 
 const createProposal = async (

--- a/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
+++ b/src/queue/consumers/scicat/scicatProposal/consumerCallbacks/upsertProposalInScicat.ts
@@ -105,7 +105,7 @@ const createInstrumentsObject = (instruments: Instrument[]) => {
         unit: '',
       };
       instrumentsObject[`instrument_time_${index + 1}`] = {
-        value: instrument.allocatedTime / 86400,
+        value: instrument.allocatedTime / 86400 || NaN,
         unit: 'days',
       };
     }

--- a/src/queue/consumers/scicat/scicatProposal/dto.ts
+++ b/src/queue/consumers/scicat/scicatProposal/dto.ts
@@ -13,6 +13,7 @@ export type CreateProposalDto = {
   startTime?: Date;
   endTime?: Date;
   MeasurementPeriodList: any[];
+  metadata?: Record<string, unknown>;
 };
 
 export type UpdateProposalDto = {
@@ -29,6 +30,7 @@ export type UpdateProposalDto = {
   startTime?: Date;
   endTime?: Date;
   MeasurementPeriodList?: any[];
+  metadata?: Record<string, unknown>;
 };
 
 export interface Institution {


### PR DESCRIPTION
…bject creation

<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This update adds instrument information to proposal objects sent to SciCat. A new metadata field is included in both CreateProposalDto and UpdateProposalDto. This metadata contains each instrument's short code and allocated time (in days).

## Motivation and Context

This makes instrument usage clearer and easier to track in SciCat.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

<!--- What types of changes does your code introduce? In what place? -->

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated

## Summary by Sourcery

Extend the proposal DTOs with a metadata field and populate it with structured instrument data using a new helper function

New Features:
- Add optional metadata field to CreateProposalDto and UpdateProposalDto
- Implement createInstrumentsObject helper to map instruments array into metadata entries
- Include metadata in proposal creation and update workflows by invoking createInstrumentsObject