### PR TITLE
feat: enforce serial message processing in OneIdentityIntegrationQueueConsumer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@user-office-software/duo-logger": "^2.3.2",
-        "@user-office-software/duo-message-broker": "^1.8.0",
+        "@user-office-software/duo-message-broker": "^1.9.0",
         "axios": "^1.15.0",
         "dotenv": "^17.3.1",
         "envalid": "^8.1.1",
@@ -2757,9 +2757,9 @@
       }
     },
     "node_modules/@user-office-software/duo-message-broker": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.8.0.tgz",
-      "integrity": "sha512-EBbwV4soqh/RBOAGR67He26S0drb/BoH/2YMxgrF2FFsqtBXsjKTRqqBX9HB9PjXFGYGnXi5OPeEiRbc6jyOHQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.9.0.tgz",
+      "integrity": "sha512-5hXprou9ihTyWXGeuXf6NDbM47GdPNGdfmb48Gl9tgxawBh7u2YQX9Z5serLBesWqy3mu1EEYjGh9Ug2FpD1Qw==",
       "license": "ISC",
       "dependencies": {
         "@types/amqplib": "^0.10.1",
@@ -12548,9 +12548,9 @@
       }
     },
     "@user-office-software/duo-message-broker": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.8.0.tgz",
-      "integrity": "sha512-EBbwV4soqh/RBOAGR67He26S0drb/BoH/2YMxgrF2FFsqtBXsjKTRqqBX9HB9PjXFGYGnXi5OPeEiRbc6jyOHQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@user-office-software/duo-message-broker/-/duo-message-broker-1.9.0.tgz",
+      "integrity": "sha512-5hXprou9ihTyWXGeuXf6NDbM47GdPNGdfmb48Gl9tgxawBh7u2YQX9Z5serLBesWqy3mu1EEYjGh9Ug2FpD1Qw==",
       "requires": {
         "@types/amqplib": "^0.10.1",
         "@user-office-software/duo-logger": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@user-office-software/duo-logger": "^2.3.2",
-    "@user-office-software/duo-message-broker": "^1.8.0",
+    "@user-office-software/duo-message-broker": "^1.9.0",
     "axios": "^1.15.0",
     "dotenv": "^17.3.1",
     "envalid": "^8.1.1",

--- a/src/queue/consumers/QueueConsumer.spec.ts
+++ b/src/queue/consumers/QueueConsumer.spec.ts
@@ -59,7 +59,25 @@ describe('QueueConsumer', () => {
 
     expect(messageBrokerMock.listenOn).toHaveBeenCalledWith(
       'testQueue',
-      expect.any(Function)
+      expect.any(Function),
+      {}
+    );
+  });
+
+  it('should pass prefetch to listenOn when getPrefetch returns a number', async () => {
+    class PrefetchQueueConsumer extends TestQueueConsumer {
+      protected getPrefetch() {
+        return 1;
+      }
+    }
+
+    const prefetchConsumer = new PrefetchQueueConsumer(messageBrokerMock);
+    await prefetchConsumer.start();
+
+    expect(messageBrokerMock.listenOn).toHaveBeenCalledWith(
+      'testQueue',
+      expect.any(Function),
+      { prefetch: 1 }
     );
   });
 

--- a/src/queue/consumers/QueueConsumer.ts
+++ b/src/queue/consumers/QueueConsumer.ts
@@ -1,6 +1,7 @@
 import { logger } from '@user-office-software/duo-logger';
 import {
   ConsumerCallback,
+  ListenOnOptions,
   MessageBroker,
   Queue,
 } from '@user-office-software/duo-message-broker';
@@ -28,6 +29,13 @@ export abstract class QueueConsumer {
     message: Record<string, string>
   ): Record<string, string>;
 
+  // Override in subclasses to set a RabbitMQ prefetch count (QoS) for this
+  // consumer's queue. Returning undefined means no
+  // prefetch is set (default broker behaviour — unlimited in-flight messages).
+  protected getPrefetch(): number | undefined {
+    return undefined;
+  }
+
   abstract onMessage: ConsumerCallback;
 
   async start(): Promise<void> {
@@ -48,37 +56,47 @@ export abstract class QueueConsumer {
 
     await this.messageBroker.addQueueToExchangeBinding(queueName, exchangeName);
 
-    this.messageBroker.listenOn(queueName as Queue, async (...args) => {
-      logger.logInfo('Received message on queue', { queueName });
+    const listenOnOptions: ListenOnOptions = {};
+    const prefetch = this.getPrefetch();
+    if (prefetch !== undefined) {
+      listenOnOptions.prefetch = prefetch;
+    }
 
-      // Start tracking processing time
-      const endTimer = processingDurationHistogram.startTimer({
-        queue: queueName,
-      });
+    this.messageBroker.listenOn(
+      queueName as Queue,
+      async (...args) => {
+        logger.logInfo('Received message on queue', { queueName });
 
-      try {
-        await this.onMessage(...args);
-
-        // Increment the success counter
-        processedMessagesCounter.inc({ queue: queueName, status: 'success' });
-      } catch (error) {
-        logger.logException('Error while handling QueueConsumer callback: ', {
-          error: (error as Error).message,
-          queue: this.getQueueName(),
-          consumer: this.constructor.name,
-          args,
+        // Start tracking processing time
+        const endTimer = processingDurationHistogram.startTimer({
+          queue: queueName,
         });
 
-        // Increment the failure counter
-        processedMessagesCounter.inc({ queue: queueName, status: 'failure' });
+        try {
+          await this.onMessage(...args);
 
-        // Re-throw the error to make sure the message is not acknowledged
-        throw error;
-      } finally {
-        // Stop the timer
-        endTimer();
-      }
-    });
+          // Increment the success counter
+          processedMessagesCounter.inc({ queue: queueName, status: 'success' });
+        } catch (error) {
+          logger.logException('Error while handling QueueConsumer callback: ', {
+            error: (error as Error).message,
+            queue: this.getQueueName(),
+            consumer: this.constructor.name,
+            args,
+          });
+
+          // Increment the failure counter
+          processedMessagesCounter.inc({ queue: queueName, status: 'failure' });
+
+          // Re-throw the error to make sure the message is not acknowledged
+          throw error;
+        } finally {
+          // Stop the timer
+          endTimer();
+        }
+      },
+      listenOnOptions
+    );
     logger.logInfo('Listening on queue', { queueName });
   }
 }

--- a/src/queue/consumers/oneidentity/OneIdentityIntegrationQueueConsumer.spec.ts
+++ b/src/queue/consumers/oneidentity/OneIdentityIntegrationQueueConsumer.spec.ts
@@ -31,6 +31,13 @@ describe('OneIdentityIntegrationQueueConsumer', () => {
     consumer = new OneIdentityIntegrationQueueConsumer({} as MessageBroker);
   });
 
+  it('should return prefetch count of 1 to ensure serial message processing', () => {
+    // Access the protected method via the prototype
+    expect(OneIdentityIntegrationQueueConsumer.prototype['getPrefetch']()).toBe(
+      1
+    );
+  });
+
   describe('onMessage', () => {
     it('should not handle message if type is not PROPOSAL_ACCEPTED or PROPOSAL_UPDATED', async () => {
       const message = {} as ProposalMessageData;

--- a/src/queue/consumers/oneidentity/OneIdentityIntegrationQueueConsumer.ts
+++ b/src/queue/consumers/oneidentity/OneIdentityIntegrationQueueConsumer.ts
@@ -29,6 +29,12 @@ const SYNC_VISIT_EVENTS_FOR_HANDLING = [
 
 // Class for consuming messages from the ESS One Identity Integration Queue
 export class OneIdentityIntegrationQueueConsumer extends QueueConsumer {
+  // Limit in-flight messages to 1 so RabbitMQ withholds the next message until
+  // the current one is acked/nacked, preventing race conditions in One Identity.
+  protected getPrefetch(): number | undefined {
+    return 1;
+  }
+
   getQueueName(): string {
     return ONE_IDENTITY_INTEGRATION_QUEUE_NAME;
   }


### PR DESCRIPTION
Upgrades @user-office-software/duo-message-broker to v1.9.0, which exposes prefetch configuration. Adds getPrefetch() support to the base QueueConsumer class and overrides it in OneIdentityIntegrationQueueConsumer with a value of 1, ensuring RabbitMQ delivers only one message at a time and preventing race conditions in One Identity Consumer during concurrent proposal/visit syncs.